### PR TITLE
Document privacy issues arising from flash seqno leasing

### DIFF
--- a/draft-ietf-core-object-security.md
+++ b/draft-ietf-core-object-security.md
@@ -533,7 +533,7 @@ An AEAD nonce MUST NOT be used more than once per AEAD key. In order to assure u
 
 In order to protect from replay of messages, each Recipient Context contains a Replay Window used to verify request, and - in case of Observe - responses. A receiving endpoint SHALL verify that a Sequence Number (Partial IV) received in the COSE object has not been received before in the Recipient Context. The size and type of the Replay Window depends on the use case and lower protocol layers. In case of reliable and ordered transport from endpoint to endpoint, the recipient MAY just store the last received sequence number and require that newly received Sequence Numbers equals the last received Sequence Number + 1.
 
-## Sequence Number and Replay Window State ##
+## Sequence Number and Replay Window State ## {#seqno-replay-state}
 
 To prevent reuse of the Nonce/Sequence Number with the same key, or from accepting replayed messages, a node needs to handle the situation of suddenly losing sequence number and replay window state in RAM, e.g. as a result of a reboot.
 
@@ -697,6 +697,8 @@ Privacy threats executed through intermediate nodes are considerably reduced by 
 The unprotected options ({{protected-coap-options}}) may reveal privacy sensitive information. In particular Uri-Host  SHOULD NOT contain privacy sensitive information. 
 
 CoAP headers sent in plaintext allow for example matching of CON and ACK (CoAP Message Identifier), matching of request and responses (Token) and traffic analysis.
+
+Using the mechanisms described in {{seqno-replay-state}} reveals when a device goes through a reboot. This can be mitigated by the device storing the precise state of sender sequence number and recipient replay window on a clean shutdown.
 
 # IANA Considerations {#iana}
 


### PR DESCRIPTION
Not a grave issue, but it's a leak of information that can be reduced to
leaking unexpected reboots vs. leaking any reboot by being aware of it.