### PR TITLE
Replay syncing with Repeat: be more explicit about what is encrypted

### DIFF
--- a/draft-ietf-core-object-security.md
+++ b/draft-ietf-core-object-security.md
@@ -583,7 +583,11 @@ To prevent reuse of Sender Sequence Numbers, a node MAY perform the following pr
 
 To prevent accepting replay of previously received requests, the server MAY perform the following procedure after boot:
 
-* For each stored security context, the first time after boot the server receives an OSCORE request, the server uses the Repeat option {{I-D.amsuess-core-repeat-request-tag}} to get a request with verifiable freshness and uses that to synchronize the replay window. If the server can verify the fresh request, the Partial IV in the fresh request is set as the lower limit of the replay window.
+* For each stored security context, the first time after boot the server receives an OSCORE request, the server uses the Repeat option {{I-D.amsuess-core-repeat-request-tag}} to get a request with verifiable freshness.
+
+  The Request option in the server's response MUST be encrypted, and the server MUST NOT use the same nonce as the request in its reply.
+
+  If the server can verify a second request as fresh, the Partial IV of the second request is set as the lower limit of the replay window.
 
 ### Replay Protection of Observe Notifications
 


### PR DESCRIPTION
This prescribes explicitly one of the possible ways that the response is sent, and states the (hopefully) obvious about accepting new requests.

The alternative to "MUST NOT be encrypted" would be "MUST be encrypted and MUST carry an explicit IV"; even both would work, but clients need to know what they need to be prepared for.

---

I'd be fine with either of the two (or three) versions of the request encryption, but not stating anything might result in incompatible implementations where one only works this and one only works that way.

Being explicit about (to us) obvious things like not responding with an implied IV or not accepting Repeat as Class U (or in an unencrypted request that might then clear the way for any replays) might not be necessary from a specification point of view, but could avoid implementation errors I see very vividly before my inner eye.